### PR TITLE
Fixed issue when function wasn't able to remove characters

### DIFF
--- a/bigfunctions/remove_strings.yaml
+++ b/bigfunctions/remove_strings.yaml
@@ -21,4 +21,4 @@ examples:
     output: "I  dies"
     region: ALL
 code: |
-  (select regexp_replace(string, '(' || array_to_string(strings_to_remove, '|') || ')', ''))
+  (select regexp_replace(string, '(' || array_to_string(array(select case when (regexp_contains(str, r"[!-\/:-@[-`{-~]")) then "\\" || str else str end from unnest(strings_to_remove) as str), '|') || ')', ''))

--- a/bigfunctions/remove_strings.yaml
+++ b/bigfunctions/remove_strings.yaml
@@ -21,4 +21,14 @@ examples:
     output: "I  dies"
     region: ALL
 code: |
-  (select regexp_replace(string, '(' || array_to_string(array(select case when (regexp_contains(str, r"[!-\/:-@[-`{-~]")) then "\\" || str else str end from unnest(strings_to_remove) as str), '|') || ')', ''))
+  (
+  with escaped_strings_to_remove as (
+    select regexp_replace(str, r'(\.|\+|\*|\?|\^|\$|\(|\)|\[|\]|\{|\}|\||\\)', r'\\\1') as str
+    from unnest(strings_to_remove) as str
+  )
+  select regexp_replace(
+    string, 
+    '(' || array_to_string((select array_agg(str) from escaped_strings_to_remove), '|') || ')',
+    ''
+  )
+  )


### PR DESCRIPTION
Linked to issue #58 

`select bigfunctions.eu.remove_strings('test_-test test()', ['_', '-',' ','(',')']) as cleaned_string` returns `testtesttest()`
And
`select bigfunctions.eu.remove_strings('test_-test test()', ['(',')','_', '-',' ']) as cleaned_string` returns `test_-test test()`
whereas the expected output is `testtesttest`

This was happening because the characters that are used in regex expressions need to be replaced from the source string. So these characters (like `(`, `)`, `-`, etc.) need to be escaped if we want to remove them from source strings. Otherwise, those characters will be treated as a regex expression and we'll end up with incorrect replacements. 