### PR TITLE
Added new bigfunction for converting XML string into JSON.

### DIFF
--- a/bigfunctions/xml2json.yaml
+++ b/bigfunctions/xml2json.yaml
@@ -1,0 +1,39 @@
+type: function_js
+category: transform_string
+author:
+  name: Shivam Singh
+  url: https://www.linkedin.com/in/shivamsingh012/
+  avatar_url: "https://media.licdn.com/dms/image/D4D03AQERv0qwECH0DA/profile-displayphoto-shrink_200_200/0/1675233460732?e=1686182400&v=beta&t=HqngiSx5zd4llZStwf3L0k2T_pE8qvnEj7NguWNJTOo"
+description: Returns JSON as a string for given XML string
+arguments:
+  - name: xml
+    type: string
+output:
+  name: json
+  type: string
+examples:
+  - description: ""
+    arguments:
+      - "'<a><b>foo</b></a>'"
+    output: '{"a":{"b":"foo"}}'
+    region: ALL
+  - description: ""
+    arguments:
+      - "'<a></a>'"
+    output: '{"a":""}'
+    region: ALL
+  - description: ""
+    arguments:
+      - "'<a></a'"
+    output: null
+    region: ALL
+code: |
+  const isValid = fast_xml_parser.XMLValidator.validate(xml);
+  if (typeof isValid === "boolean"){
+      const parser = new fast_xml_parser.XMLParser();
+      let jsonObj = parser.parse(xml);
+      return JSON.stringify(jsonObj);
+  }
+  return null;
+libraries:
+  - fast-xml-parser-v4.1.3.min.js


### PR DESCRIPTION
Linked to issue #33 

A function `xml2json` is added for converting an XML string into a JSON string.

When the given XML has an invalid format then it returns `null`, otherwise returns JSON string.

Valid String Example - 
![image](https://user-images.githubusercontent.com/56783600/230651067-6965836a-fc98-469a-ab6f-659a2c0391b2.png)

Invalid String Example -
![image](https://user-images.githubusercontent.com/56783600/230651230-36616c8c-1344-4c0b-94bc-f9862706fef3.png)
