### PR TITLE
Add get_benfords_distance BigFunction to Analyze Data for Conformity with Benford's Law

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ tests/
 site/
 
 TEST
+venv

--- a/bigfunctions/detect_anomalies.yaml
+++ b/bigfunctions/detect_anomalies.yaml
@@ -1,0 +1,53 @@
+type: function_py
+category: detect_anomalies
+author:
+  name: Thomas F McGeehan V
+  url: https://www.linkedin.com/in/tfmv5
+description: |
+  Detect anomalies in time-series data to identify outliers and unusual patterns.
+  This function uses Z-score to find anomalies in the specified column of a BigQuery table.
+arguments:
+  - name: dataset_name
+    type: string
+  - name: table_name
+    type: string
+  - name: time_column
+    type: string
+  - name: value_column
+    type: string
+  - name: threshold
+    type: float64
+    description: "Threshold for Z-score to consider a value as an anomaly."
+output:
+  name: anomalies
+  type: string
+examples:
+  - description: "Detect anomalies in 'orders' table"
+    arguments:
+      - "'tpch'"
+      - "'orders'"
+      - "'o_orderdate'"
+      - "'o_totalprice'"
+      - "3.0"
+    output: |
+      '[{"time": "2023-01-15", "value": 10000.0, "z_score": 3.5}, {"time": "2023-02-10", "value": 15000.0, "z_score": 4.2}]'
+code: |
+  import pandas as pd
+  import json
+
+  def detect_anomalies(dataset_name, table_name, time_column, value_column, threshold):
+      query = f"SELECT {time_column}, {value_column} FROM `{dataset_name}.{table_name}`"
+      df = pd.read_gbq(query, project_id='your-gcp-project-id')
+      df['z_score'] = (df[value_column] - df[value_column].mean()) / df[value_column].std()
+      anomalies = df[df['z_score'].abs() > threshold]
+      results = [
+          {"time": row[time_column], "value": row[value_column], "z_score": row['z_score']}
+          for _, row in anomalies.iterrows()
+      ]
+      return json.dumps(results, ensure_ascii=False)
+
+  anomalies = detect_anomalies(dataset_name, table_name, time_column, value_column, threshold)
+  anomalies
+requirements: |
+  pandas
+  google-cloud-bigquery

--- a/bigfunctions/get_ngram_frequency_similarity.yaml
+++ b/bigfunctions/get_ngram_frequency_similarity.yaml
@@ -1,0 +1,65 @@
+type: function_sql
+category: text_analysis
+author:
+  name: Thomas F McGeehan V
+  url: https://www.linkedin.com/in/tfmv5
+description: |
+  Calculate n-gram frequency similarity between two strings.
+  This function computes the cosine similarity between n-grams of the given strings.
+arguments:
+  - name: strone
+    type: string
+  - name: strtwo
+    type: string
+  - name: n
+    type: int64
+output:
+  name: similarity
+  type: float64
+examples:
+  - description: "Calculate n-gram frequency similarity between two simple strings with n=2"
+    arguments:
+      - "'hello world'"
+      - "'world hello'"
+      - "2"
+    output: "0.8"
+  - description: "Calculate n-gram frequency similarity between two phrases with n=3"
+    arguments:
+      - "'The quick brown fox'"
+      - "'The quick brown dog'"
+      - "3"
+    output: "0.9"
+  - description: "Calculate n-gram frequency similarity between two sentences with n=4"
+    arguments:
+      - "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'"
+      - "'Lorem ipsum dolor sit amet, consectetur adipiscing.'"
+      - "4"
+    output: "0.95"
+code: |
+  (
+    select
+      if(magnitude1 * magnitude2 = 0, 0, dot_product / (magnitude1 * magnitude2)) as similarity
+    from (
+      select
+        sqrt(sum(freq1 * freq1)) as magnitude1,
+        sqrt(sum(freq2 * freq2)) as magnitude2,
+        sum(freq1 * freq2) as dot_product
+      from (
+        select
+          coalesce(ngrams_one.ngram, ngrams_two.ngram) as ngram,
+          coalesce(ngrams_one.frequency, 0) as freq1,
+          coalesce(ngrams_two.frequency, 0) as freq2
+        from (
+          select substr(upper(strone), pos, n) as ngram, count(*) as frequency
+          from unnest(generate_array(1, length(strone) - n + 1)) as pos
+          group by ngram
+        ) as ngrams_one
+        full outer join (
+          select substr(upper(strtwo), pos, n) as ngram, count(*) as frequency
+          from unnest(generate_array(1, length(strtwo) - n + 1)) as pos
+          group by ngram
+        ) as ngrams_two
+        on ngrams_one.ngram = ngrams_two.ngram
+      )
+    )
+  )


### PR DESCRIPTION
This PR introduces a new BigFunction, get_benfords_distance, designed to calculate the Chi-square distance from Benford's Law for a given column of numeric data. This function helps identify if a dataset conforms to the expected distribution of leading digits according to Benford's Law.

Call it like so:

select tfmv.get_benfords_distance(array(select ps_supplycost from `tpch.partsupp`)) as benfords_distance;

0.40100993568023274

Example use cases:

Financial Audits: Identify anomalies in financial data, such as revenue or expense accounts.

Sales Data Analysis: Ensure the integrity of sales data by comparing observed leading digit distribution to Benford's Law.

Inventory Management: Verify the distribution of inventory costs or quantities against Benford's Law to uncover discrepancies.