### PR TITLE
make geocoding exception not breaking all rows

### DIFF
--- a/bigfunctions/transform_geo_data/geocode.yaml
+++ b/bigfunctions/transform_geo_data/geocode.yaml
@@ -30,10 +30,14 @@ code: |
   import json
   import googlemaps
   gmaps = googlemaps.Client(key=gmaps_api_key)
-  results = gmaps.geocode(address)
-  if not results:
-      return
-  return json.dumps(results[0], ensure_ascii=False)
+  try:
+    results = gmaps.geocode(address)
+    if not results:
+        return None
+    return json.dumps(results[0], ensure_ascii=False)
+  except Exception as e:
+        error_message = f"Unexpected error : {e}"
+        return error_message  
 requirements: |
   googlemaps
 secrets:


### PR DESCRIPTION
Exceptions were not catched, so possibly, if 9 999 rows were geocoded but 1 fails,  the SQL Query broke and all the rows were lost. Change is that the exception is return as text in the sql result