### PR TITLE
Fix AdaptiveCard text wrapping issue in Teams messages

### DIFF
--- a/bigfunctions/notify/send_teams_message.yaml
+++ b/bigfunctions/notify/send_teams_message.yaml
@@ -32,9 +32,9 @@ code: |
           'contentType': 'application/vnd.microsoft.card.adaptive',
           'content': {
             'type': 'AdaptiveCard',
-            'body': [{'type': 'TextBlock', 'text': message}],
+            'body': [{'type': 'TextBlock', 'text': message, 'wrap': True}],
             '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-            'version': '1.0'
+            'version': '1.4'
           }
         }]
       })


### PR DESCRIPTION
Previously, long messages in AdaptiveCard were being truncated, making it difficult to read the entire content. This PR fixes the issue by enabling text wrapping (wrap: true) inside the TextBlock, allowing long messages to continue on the next line instead of being cut off.
Before:
![image_2025-02-14_014743325](https://github.com/user-attachments/assets/14bafdb1-bd06-44ff-8880-a71c55ec8aaf)
After:
![image](https://github.com/user-attachments/assets/0a29b0ca-a980-4b2b-8385-a19b6724f084)
