### PR TITLE
fix: enable full width for Teams adaptive card messages

### DIFF
--- a/bigfunctions/notify/send_teams_message.yaml
+++ b/bigfunctions/notify/send_teams_message.yaml
@@ -33,6 +33,7 @@ code: |
           'content': {
             'type': 'AdaptiveCard',
             'body': [{'type': 'TextBlock', 'text': message, 'wrap': True}],
+            'msTeams': {'width': 'full'},
             '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
             'version': '1.4'
           }


### PR DESCRIPTION
To make adaptive card like 2nd message
![image](https://github.com/user-attachments/assets/dd1efeef-9b10-4549-8f2b-0bc6385042d3)
