### PR TITLE
fix: update exchange rate UTC time and improve cache validation

### DIFF
--- a/bigfunctions/get_data/exchange_rate.yaml
+++ b/bigfunctions/get_data/exchange_rate.yaml
@@ -38,9 +38,9 @@ code: | #python
   if (base not in country_codes_iso4217) or (to not in country_codes_iso4217):
     return None
 
-  today = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+  today = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
   cache_key = f'{today}_{base}_{to}'
-  if cache_key not in CACHE:
+  if cache_key not in CACHE or CACHE[cache_key] is None:
     ticker_name = f'{base}{to}=X'
     ticker = yf.Ticker(ticker_name)
     try:


### PR DESCRIPTION
• Uses `datetime.datetime.now(datetime.UTC)` since `datetime.datetime.utcnow()` is deprecated. 
• Checks if `CACHE[cache_key] is None` to try out get the current rate again.