### PR TITLE
fix: ensure directory exists for generated code_filename

### DIFF
--- a/bigfun/bigfunctions.py
+++ b/bigfun/bigfunctions.py
@@ -157,6 +157,7 @@ class BigFunction:
         os.makedirs(TESTS_FOLDER, exist_ok=True)
         code_filename = f'{TESTS_FOLDER}/bf__{self.name}.py'
         print_info(f'Generating python code file {code_filename}')
+        os.makedirs(os.path.dirname(code_filename), exist_ok=True)
         with open(code_filename, 'w', encoding='utf-8') as out:
             out.write(code)
         print_info(f'Executing python code file {code_filename}')


### PR DESCRIPTION
`bigfun test bigfunctions\get_data\exchange_rate` returns error if `test/bigfunctions/get_data/exchange_rate.py` doesn't exists
![image](https://github.com/user-attachments/assets/283b4845-8fcc-4559-b82b-fcb5a4990675)


I added a step to control if it exists `os.makedirs(os.path.dirname(code_filename), exist_ok=True)` and worked well
![image](https://github.com/user-attachments/assets/50ee6395-27ed-46ec-9c6a-772ce1c4e1d3)
