### PR TITLE
feat: add format_readable_quantity and format_readable_size functions

### DIFF
--- a/bigfunctions/transform/transform_numeric/format_readable_quantity.yaml
+++ b/bigfunctions/transform/transform_numeric/format_readable_quantity.yaml
@@ -1,0 +1,47 @@
+type: function_sql
+
+category: transform_numeric
+
+author:
+  name: Janga Venkata Phanindra Reddy
+  url: https://www.linkedin.com/in/j-v-phanindra-reddy
+  avatar_url: https://avatars.githubusercontent.com/u/41366590
+
+description: |
+  Return a human-readable string representation of a large number.
+  Converts large integers into compact format with K, M, B suffixes
+  (e.g. `8000000` → `8.0M`, `67000` → `67.0K`).
+
+arguments:
+  - name: value
+    type: float64
+
+output:
+  name: readable_quantity
+  type: string
+
+examples:
+  - description: "millions"
+    arguments:
+      - "8000000"
+    output: "8.0M"
+  - description: "thousands"
+    arguments:
+      - "67000"
+    output: "67.0K"
+  - description: "billions"
+    arguments:
+      - "2500000000"
+    output: "2.5B"
+  - description: "small number (no suffix)"
+    arguments:
+      - "500"
+    output: "500.0"
+
+body: |
+  case
+    when value >= 1000000000 then concat(cast(round(value / 1000000000, 1) as string), 'B')
+    when value >= 1000000    then concat(cast(round(value / 1000000, 1) as string), 'M')
+    when value >= 1000       then concat(cast(round(value / 1000, 1) as string), 'K')
+    else cast(round(value, 1) as string)
+  end

--- a/bigfunctions/transform/transform_numeric/format_readable_size.yaml
+++ b/bigfunctions/transform/transform_numeric/format_readable_size.yaml
@@ -1,0 +1,30 @@
+type: function_sql
+
+category: transform_numeric
+
+author:
+  name: Janga Venkata Phanindra Reddy
+  url: https://www.linkedin.com/in/j-v-phanindra-reddy
+  avatar_url: https://avatars.githubusercontent.com/u/41366590
+
+description: |
+  Return a human-readable string representation of a byte size.
+  Converts byte counts into compact format with KB, MB, GB, TB suffixes
+  (e.g. `67000` → `65.4 KiB`, `1073741824` → `1.0 GiB`).
+
+arguments:
+  - name: bytes
+    type: float64
+
+output:
+  name: readable_size
+  type: string
+
+body: |
+  case
+    when bytes >= 1099511627776 then concat(cast(round(bytes / 1099511627776, 1) as string), ' TiB')
+    when bytes >= 1073741824    then concat(cast(round(bytes / 1073741824, 1) as string), ' GiB')
+    when bytes >= 1048576       then concat(cast(round(bytes / 1048576, 1) as string), ' MiB')
+    when bytes >= 1024          then concat(cast(round(bytes / 1024, 1) as string), ' KiB')
+    else concat(cast(bytes as string), ' B')
+  end


### PR DESCRIPTION
**Found these kind of functions in Clickhouse, thought it will be helpful if we have in BQ as well**
**format_readable_quantity**: Converts large numbers to human-readable format with K/M/B suffixes (8000000 → 8.0M)
**format_readable_size**: Converts bytes to human-readable file sizes with B/KB/MB/GB suffixes